### PR TITLE
Allow runtime exceptions to be written to the output

### DIFF
--- a/src/Scriban.Tests/TestRuntime.cs
+++ b/src/Scriban.Tests/TestRuntime.cs
@@ -529,6 +529,28 @@ Tax: {{ 7 | match_tax }}";
         }
 
         [Test]
+        public void TestRenderRuntimeException()
+        {
+            var template = Template.Parse("Test {{ 'error' | unknown }} behind");
+            var context = new TemplateContext();
+            context.RenderRuntimeException = TemplateContext.RenderRuntimeExceptionDefault;
+            context.Evaluate(template.Page);
+            var result = context.Output.ToString();
+            Assert.True(System.Text.RegularExpressions.Regex.IsMatch(result, @"^Test \[.+\] behind$"));
+        }
+
+        [Test]
+        public void TestRenderRuntimeExceptionWithCustomFormat()
+        {
+            var template = Template.Parse("Test {{ 'error' | unknown }} behind");
+            var context = new TemplateContext();
+            context.RenderRuntimeException = ex => string.Format("#Scriban-Exception:{0}#", ex.OriginalMessage);
+            context.Evaluate(template.Page);
+            var result = context.Output.ToString();
+            Assert.True(System.Text.RegularExpressions.Regex.IsMatch(result, @"^Test #Scriban-Exception:.+# behind$"));
+        }
+
+        [Test]
         public void TestRelaxedMemberAccess()
         {
             var scriptObject = new ScriptObject

--- a/src/Scriban/Syntax/ScriptRuntimeException.cs
+++ b/src/Scriban/Syntax/ScriptRuntimeException.cs
@@ -30,6 +30,18 @@ namespace Scriban.Syntax
                 return new LogMessage(ParserMessageType.Error, Span, base.Message).ToString();
             }
         }
+
+        /// <summary>
+        /// Provides the exception message without the source span prefix.
+        /// </summary>
+        public string OriginalMessage
+        {
+            get
+            {
+                return base.Message;
+            }
+        }
+
         public override string ToString()
         {
             return Message;

--- a/src/Scriban/Template.cs
+++ b/src/Scriban/Template.cs
@@ -232,7 +232,7 @@ namespace Scriban
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             CheckErrors();
-
+            
             // Make sure that we are using the same parserOptions
             if (SourceFilePath != null)
             {


### PR DESCRIPTION
When the `RenderRuntimeException` property on a `TemplateContext` is set to an instance of the `TemplateContext.RenderRuntimeExceptionDelegate`, no exceptions while rendering will be thrown.
Instead the exception message text is rendered to the output text.